### PR TITLE
suppression de la clause non-commerciale

### DIFF
--- a/resources/lang/fr/ui.yaml
+++ b/resources/lang/fr/ui.yaml
@@ -29,7 +29,7 @@ index:
     p1: |
       Le projet Paxo adhère aux principes du logiciel libre, aussi bien au niveau du matériel que du logiciel. Cela
       signifie qu’il confère à chacun la liberté d'utliliser, d'étudier, d'adapter et de redistribuer les plans et le
-      code du téléphone (dans un cadre non-commercial).
+      code du téléphone.
     p2: |
       Cette dimension libre du projet accorde un place centrale à la communautée. Par ses contributions, elle aide à
       faire évoluer le projet.


### PR DESCRIPTION
La licence retenue (AGPL v3) impose explicitement la liberté d’utilisation du projet, y compris commerciale.

Si vous souhaitez interdire l’utilisation commerciale, il faut choisir une licence non-libre, par exemple la [CC BY-NC](https://creativecommons.org/licenses/by-nc/4.0/deed.fr) ou [CC BY-NC-SA](https://creativecommons.org/licenses/by-nc-sa/4.0/deed.fr).

Si vous souhaitez utiliser une licence libre, la GPL serait plus adaptée que l’AGPL tout en conservant l’esprit copyleft.